### PR TITLE
Bazel build to bazel run

### DIFF
--- a/rules_lodestar/app/BUILD.bazel
+++ b/rules_lodestar/app/BUILD.bazel
@@ -1,17 +1,8 @@
-load(":app.bzl", "app_promote", "app_push")
+load(":app.bzl", "app_push")
 
 app_push(
     name = "push_example",
     app_config = "lodestar-folder-app-example.yaml",
     environment = "dev",
-    lodestar = "//cmd/lodestar",
     yaml_keys = "$(yaml-keys)",
-)
-
-app_promote(
-    name = "promote_example",
-    app_config = "lodestar-folder-app-example.yaml",
-    dest_env = "qa",
-    lodestar = "//cmd/lodestar",
-    src_env = "dev",
 )

--- a/rules_lodestar/app/BUILD.bazel
+++ b/rules_lodestar/app/BUILD.bazel
@@ -5,7 +5,7 @@ app_push(
     app_config = "lodestar-folder-app-example.yaml",
     environment = "dev",
     lodestar = "//cmd/lodestar",
-    tag = "$(tag)",
+    yaml_keys = "$(yaml-keys)",
 )
 
 app_promote(

--- a/rules_lodestar/app/app.bzl
+++ b/rules_lodestar/app/app.bzl
@@ -1,21 +1,23 @@
-def app_push(name, lodestar, app_config, environment, tag):
+def app_push(name, lodestar, app_config, environment, yaml_keys):
   native.genrule(
     name = name,
+    executable = True,
     srcs = [
-        lodestar,
         app_config
     ],
-    outs = ["app_push_"+name+".txt"],
-    cmd_bash = "$(locations "+lodestar+") app push --config-path $(locations "+app_config+") --env "+environment+" --tag "+tag+" > $@",
+    exec_tools = [lodestar],
+    outs = ["app_push_"+name+".sh"],
+    cmd_bash = "$(location "+lodestar+") app push --config-path $(locations "+app_config+") --env "+environment+" --yaml-keys "+yaml_keys+" && echo \"echo Lodestar Push Complete!\" > $@",
 )
 
 def app_promote(name, lodestar, app_config, src_env, dest_env):
   native.genrule(
     name = name,
+    executable = True,
     srcs = [
-        lodestar,
         app_config
     ],
-    outs = ["app_push_"+name+".txt"],
-    cmd_bash = "$(locations "+lodestar+") app promote --config-path $(locations "+app_config+") --src-env "+src_env+" --dest-env "+dest_env+" > $@",
+    exec_tools = [lodestar],
+    outs = ["app_promote_"+name+".sh"],
+    cmd_bash = "$(locations "+lodestar+") app promote --config-path $(locations "+app_config+") --src-env "+src_env+" --dest-env "+dest_env+" && echo \"echo Lodestar Promote Complete!\" > $@",
 )

--- a/rules_lodestar/app/app.bzl
+++ b/rules_lodestar/app/app.bzl
@@ -1,23 +1,11 @@
-def app_push(name, lodestar, app_config, environment, yaml_keys):
+def app_push(name, app_config, environment, yaml_keys):
   native.genrule(
     name = name,
     executable = True,
     srcs = [
         app_config
     ],
-    exec_tools = [lodestar],
+    exec_tools = ["//cmd/lodestar:lodestar"],
     outs = ["app_push_"+name+".sh"],
-    cmd_bash = "$(location "+lodestar+") app push --config-path $(locations "+app_config+") --env "+environment+" --yaml-keys "+yaml_keys+" && echo \"echo Lodestar Push Complete!\" > $@",
-)
-
-def app_promote(name, lodestar, app_config, src_env, dest_env):
-  native.genrule(
-    name = name,
-    executable = True,
-    srcs = [
-        app_config
-    ],
-    exec_tools = [lodestar],
-    outs = ["app_promote_"+name+".sh"],
-    cmd_bash = "$(locations "+lodestar+") app promote --config-path $(locations "+app_config+") --src-env "+src_env+" --dest-env "+dest_env+" && echo \"echo Lodestar Promote Complete!\" > $@",
+    cmd_bash = "$(location //cmd/lodestar:lodestar) app push --config-path $(locations "+app_config+") --env "+environment+" --yaml-keys "+yaml_keys+" && echo \"echo Lodestar Push Complete!\" > $@",
 )

--- a/rules_lodestar/app/lodestar-folder-app-example.yaml
+++ b/rules_lodestar/app/lodestar-folder-app-example.yaml
@@ -1,11 +1,11 @@
-appInfo:
+info:
   name: lodestar-folder-app-example
   type: folder
   description: this is a test app
   repoUrl: https://github.com/lodestar-cli/lodestar-folder-app-example.git
   target: main
   statePath: lodestar-folder-app-example.yaml
-envGraph:
+environmentGraph:
 - name: dev
   srcPath: 1-dev/values.yaml
 - name: qa
@@ -14,3 +14,5 @@ envGraph:
   srcPath: 3-staging/values.yaml
 - name: production
   srcPath: 4-production/values.yaml
+yamlKeys:
+  - tag


### PR DESCRIPTION
Changed the app_push bazel rule to run under bazel run instead of bazel build.  Also removed app_promote.  It was buggy and I think it would be better to create docker images that have up to date lodestar installed instead of trying to cram ti into bazel for CI/CD.